### PR TITLE
Remove dhcp true because it was causing eth0 to lose the static IP

### DIFF
--- a/etc/netplan/40-ethernets.yaml
+++ b/etc/netplan/40-ethernets.yaml
@@ -5,7 +5,6 @@ network:
         eth0:
             addresses:
             - 192.168.185.3/24
-            dhcp4: true
             optional: true
         usb0:
             addresses:


### PR DESCRIPTION
## Description

Since the wired network was switched to be managed by NetworkManager this line started causing the wired NIC to drop the static IP. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)