### PR TITLE
Update the hostname in `/boot/firmware/user-data`

### DIFF
--- a/turtlebot4_setup/conf.py
+++ b/turtlebot4_setup/conf.py
@@ -130,6 +130,7 @@ class Conf():
         self.netplan_wifis_file = os.path.join(self.netplan_dir, '50-wifis.yaml')
         self.discovery_sh_file = os.path.join(self.setup_dir, 'discovery.sh')
         self.hostname_file = '/etc/hostname'
+        self.fw_user_data_file = '/boot/firmware/user-data'
 
         self.system_conf = copy.deepcopy(self.default_system_conf)
         self.wifi_conf = copy.deepcopy(self.default_wifi_conf)
@@ -229,6 +230,11 @@ class Conf():
         with open('/tmp' + self.hostname_file, 'w') as f:
             f.write(self.get(SystemOptions.HOSTNAME))
         subprocess.run(shlex.split('sudo mv /tmp' + self.hostname_file + ' ' + self.hostname_file))
+
+        # update /boot/firmware/user-data with the new hostname
+        subprocess.run(shlex.split(f'cp {self.fw_user_data_file} /tmp/user-data'))
+        subprocess.run(shlex.split(f'sed -i -E "s/^hostname:.+/hostname: {self.get(SystemOptions.HOSTNAME)}/" /tmp/user-data'))
+        subprocess.run(shlex.split(f'sudo mv /tmp/user-data {self.fw_user_data_file}'))
 
     def read_wifi(self):
         try:

--- a/turtlebot4_setup/conf.py
+++ b/turtlebot4_setup/conf.py
@@ -234,7 +234,11 @@ class Conf():
         # update /boot/firmware/user-data with the new hostname
         subprocess.run(shlex.split(f'cp {self.fw_user_data_file} /tmp/user-data'))
         subprocess.run(shlex.split(f'sed -i -E "s/^hostname:.+/hostname: {self.get(SystemOptions.HOSTNAME)}/" /tmp/user-data'))  # noqa: E501
-        subprocess.run(shlex.split(f'sudo mv /tmp/user-data {self.fw_user_data_file}'))
+        subprocess.run(
+            shlex.split(f'sudo mv /tmp/user-data {self.fw_user_data_file}'),
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
 
     def read_wifi(self):
         try:

--- a/turtlebot4_setup/conf.py
+++ b/turtlebot4_setup/conf.py
@@ -214,7 +214,12 @@ class Conf():
             system = f.readlines()
             for i, line in enumerate(system):
                 is_conf = False
-                for k in [SystemOptions.MODEL, SystemOptions.VERSION, SystemOptions.ROS]:
+                for k in [
+                    SystemOptions.MODEL,
+                    SystemOptions.VERSION,
+                    SystemOptions.ROS,
+                    SystemOptions.HOSTNAME,
+                ]:
                     if k in line:
                         system[i] = f'{k}:{self.system_conf[k]}\n'
                         is_conf = True

--- a/turtlebot4_setup/conf.py
+++ b/turtlebot4_setup/conf.py
@@ -233,7 +233,7 @@ class Conf():
 
         # update /boot/firmware/user-data with the new hostname
         subprocess.run(shlex.split(f'cp {self.fw_user_data_file} /tmp/user-data'))
-        subprocess.run(shlex.split(f'sed -i -E "s/^hostname:.+/hostname: {self.get(SystemOptions.HOSTNAME)}/" /tmp/user-data'))
+        subprocess.run(shlex.split(f'sed -i -E "s/^hostname:.+/hostname: {self.get(SystemOptions.HOSTNAME)}/" /tmp/user-data'))  # noqa: E501
         subprocess.run(shlex.split(f'sudo mv /tmp/user-data {self.fw_user_data_file}'))
 
     def read_wifi(self):


### PR DESCRIPTION
## Description

On Ubuntu Server 24.04 on Raspberry Pi editing the hostname in `/etc/hostname` alone is not sufficient to keep the new hostname to persist across reboots. `/boot/firmware/user-data` also needs to be updated with the hostname

Fixes #16.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Tested internally on `cpr-raphael` by using the `turtlebot4_setup` tool with this change.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation