### PR TITLE
Use `os.getlogin()` to set the `User` for the discovery service job

### DIFF
--- a/turtlebot4_setup/ros_setup.py
+++ b/turtlebot4_setup/ros_setup.py
@@ -408,6 +408,7 @@ class TurtleBot4Extras(robot_upstart.providers.Generic):
     def generate_install(self):
         with open('/etc/turtlebot4/discovery.conf') as f:
             discovery_conf_contents = f.read()
+            discovery_conf_contents = self.fix_conf_username(discovery_conf_contents)
         with open('/etc/turtlebot4/discovery.sh') as f:
             discovery_sh_contents = f.read()
         return {
@@ -434,3 +435,15 @@ class TurtleBot4Extras(robot_upstart.providers.Generic):
             '/etc/systemd/system/multi-user.target.wants/discovery.service': {
                 'remove': True
             }}
+
+    def fix_conf_username(self, discovery_conf_contents):
+        """
+        Replace the `User=ubuntu` text in the configuration with the current username
+
+        @return  The modified config file contents
+        """
+        if os.getlogin() == 'ubuntu':
+            # no changes needed!
+            return discovery_conf_contents
+
+        return discovery_conf_contents.replace('User=ubuntu', f'User={os.getlogin()}')


### PR DESCRIPTION
## Description

Replace `User=ubuntu` with `User={os.getlogin()}` when generating the discovery server configuration file if necessary

Fixes #14

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Simple text replacement; unit test of new function only.

Did not generate a non-standard Ubuntu installation & run the whole script.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation